### PR TITLE
Upd: pandoc

### DIFF
--- a/roles/pandoc/tasks/main.yml
+++ b/roles/pandoc/tasks/main.yml
@@ -5,13 +5,11 @@
     name: pandoc
     state: latest
 
-- name: Install PDF conversion packages
+- name: Install WeasyPrint
   become: true
   tags: pandoc
   ansible.builtin.apt:
-    name:
-      - texlive-xetex
-      - texlive-latex-recommended
-      - texlive-lang-japanese
-      - fonts-noto-cjk
+    name: weasyprint
     state: present
+
+# ref. https://weasyprint.org/start/


### PR DESCRIPTION
xetex は html の css があてられない。
このため weasyprint に切り替え。