### PR TITLE
Add: git difftool (VSCode) config

### DIFF
--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -83,3 +83,7 @@
     - { name: 'core.quotepath', value: 'false' }
     - { name: 'fetch.prune', value: 'true' }
     - { name: 'core.commentchar', value: ';' }
+    - { name: 'diff.tool', value: 'vscode' }
+    - { name: 'difftool.vscode.cmd', value: 'code --wait --diff $LOCAL $REMOTE' }
+    - { name: 'difftool.prompt', value: 'false' }
+    - { name: 'alias.dft', value: 'difftool' }


### PR DESCRIPTION
## Summary

- `diff.tool` を VSCode に設定
- `difftool.vscode.cmd` でコマンド定義
- `difftool.prompt` を false に設定（確認プロンプト無効化）
- `alias.dft` = `difftool` のエイリアス追加

Closes #27

## Test plan

- [ ] `ansible-playbook --tags git` が正常完了することを確認
- [ ] `git dft` で VSCode の差分ビューアが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)